### PR TITLE
chore: correct playbook path from upstream change

### DIFF
--- a/playbooks/all.yml
+++ b/playbooks/all.yml
@@ -3,7 +3,7 @@
 - ansible.builtin.import_playbook: nfs-server.yml
 - ansible.builtin.import_playbook: hypercore-cluster.yml
 # ansible.builtin.import_playbook: k3s.orchestration.site
-- ansible.builtin.import_playbook: ../k3s-ansible/playbook/site.yml
+- ansible.builtin.import_playbook: ../k3s-ansible/playbooks/site.yml
 - ansible.builtin.import_playbook: k3s-tools.yml
 - ansible.builtin.import_playbook: k3s-nfs-utils.yml
 - ansible.builtin.import_playbook: k3s-nfs-provisioner.yml


### PR DESCRIPTION
reference: k3s-io/k3s-ansible#330
closes: #3