### PR TITLE
Rename network interface to `eth0` using ip command

### DIFF
--- a/playbooks/hypercore-cluster.yml
+++ b/playbooks/hypercore-cluster.yml
@@ -27,7 +27,6 @@
         template2vm_user_data: "{{ lookup('template', 'user-data.ubuntu-22.04.yml.j2') }}"
         template2vm_meta_data: "{{ lookup('template', 'meta-data.ubuntu-22.04.yml.j2') }}"
         vm_name: "{{ template2vm_vm_name }}"
-        vm_network_iface: enp1s0
         vm_network_mode: static
         vm_network_ip_address: "{{ vm_ip_address }}"
       loop: "{{ server_ip_addresses }}"

--- a/playbooks/templates/meta-data.ubuntu-22.04.yml.j2
+++ b/playbooks/templates/meta-data.ubuntu-22.04.yml.j2
@@ -1,14 +1,14 @@
 dsmode: local
-local-hostname: "{{ vm_name }}"
+local-hostname: "{{ vm_name | replace('_', '-') }}"
 network-interfaces: |
   auto lo
   iface lo inet loopback
 
 {% if vm_network_mode == "dhcp" %}
-  iface {{ vm_network_iface }} inet dhcp
+  iface eth0 inet dhcp
 {% endif %}
 {% if vm_network_mode == "static" %}
-  iface {{ vm_network_iface }} inet static
+  iface eth0 inet static
     address {{ vm_network_ip_address }}
     netmask {{ vm_network_netmask }}
     gateway {{ vm_network_gateway }}

--- a/playbooks/templates/user-data.ubuntu-22.04.yml.j2
+++ b/playbooks/templates/user-data.ubuntu-22.04.yml.j2
@@ -22,18 +22,59 @@ manage_etc_hosts: localhost
 ssh_authorized_keys: {{ vm_ssh_authorized_keys }}
 disable_root: false
 ssh_import_id: {{ vm_ssh_import_id }}
-package_update: true
+# we cannot use "apt install" or "apt update",
+# the network is not up yet (we need to rename iface first)
+package_update: false
 package_upgrade: false
-packages:
- - qemu-guest-agent
+# packages:
+#  - qemu-guest-agent
 package_reboot_if_required: true
 # runcmd runs only on first boot
 runcmd:
-  - [ sh, -c, 'sudo echo GRUB_CMDLINE_LINUX="nomodeset" >> /etc/default/grub' ]
-  - [ sh, -c, 'sudo echo GRUB_GFXPAYLOAD_LINUX="1024x768" >> /etc/default/grub' ]
-  - [ sh, -c, 'sudo echo GRUB_DISABLE_LINUX_UUID=true >> /etc/default/grub' ]
-  - [ sh, -c, 'sudo update-grub' ]
-  - [ echo, message, CC-runcmd-jc ]
+  - echo 'GRUB_CMDLINE_LINUX="nomodeset"' >> /etc/default/grub
+  - echo 'GRUB_GFXPAYLOAD_LINUX="1024x768"' >> /etc/default/grub
+  - echo 'GRUB_DISABLE_LINUX_UUID=true' >> /etc/default/grub
+  - echo 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX net.ifnames=0 biosdevname=0"' >> /etc/default/grub
+  - update-grub
+
+  - |
+    echo DBG before iface-rename;
+    ip link;
+    ip addr;
+  # rename network interface
+  # cloud-init will create /etc/netplan/50-*.cfg file, just apply it.
+  - |
+    IFACE=$(ip link | grep '^2\: ' | awk '{print $2}' | sed 's/\://');
+    echo IFACE=$IFACE;
+    ip link set dev $IFACE down;
+    ip link set dev $IFACE name eth0;
+    ip link set dev eth0 up;
+    netplan apply;
+  - |
+    echo DBG after iface-rename;
+    ip link;
+    ip addr;
+
+  # pain, apt-get update seems to be run at wrong time,
+  # and it does not know about qemu-guest-agent package.
+  - |
+    for ii in $(seq 100)
+    do
+      if (apt-cache pkgnames | grep '^qemu-guest-agent$')
+      then
+        echo OK apt-cache knows about qemu-guest-agent
+        break
+      else
+        echo Waiting on apt-cache and qemu-guest-agent
+        sleep 1
+        # this is what cloud-init runs
+        eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet update
+      fi
+    done
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-guest-agent
+
+  - echo message CC-runcmd-jc
+
 # bootcmd runs on every boot
 # bootcmd:
 # qemu-guest-agent is not yet installed - packages are installed later

--- a/vars.yml
+++ b/vars.yml
@@ -32,9 +32,6 @@ load_balancer_addresses:
   - 172.31.6.50-172.31.6.58
   - 172.31.6.59/32
 
-# ubuntu22.04 BIOS - ens3
-# ubuntu22.04 UEFI - enp1s0
-vm_network_iface: ens3
 vm_network_mode: static
 
 # ----------------------------------------------------


### PR DESCRIPTION
User should not need to figure out what will be the predictable network device name (`ens3`, `enp1s0`, etc).
We want to use `eth0` device name. 

cloud-init config is a bit more complicated. In particular, `packages` cannot be used - it is run early before `runcmd`, it requires networ, and now network is setup by `runcmd`.